### PR TITLE
opensource: fix llvm warnings

### DIFF
--- a/src/dt/dt_overlay.c
+++ b/src/dt/dt_overlay.c
@@ -22,6 +22,7 @@
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #include <libfdt.h>
 #pragma clang diagnostic pop
 

--- a/src/vm_config/dtb_parser.c
+++ b/src/vm_config/dtb_parser.c
@@ -22,6 +22,7 @@
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #include <libfdt.h>
 #pragma clang diagnostic pop
 

--- a/src/vm_config/vm_config_parser.c
+++ b/src/vm_config/vm_config_parser.c
@@ -24,6 +24,7 @@
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #include <libfdt.h>
 #pragma clang diagnostic pop
 

--- a/src/vm_creation/dto_construct.c
+++ b/src/vm_creation/dto_construct.c
@@ -21,6 +21,7 @@
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #include <libfdt.h>
 #pragma clang diagnostic pop
 

--- a/src/vm_creation/vm_creation.c
+++ b/src/vm_creation/vm_creation.c
@@ -21,6 +21,7 @@
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
 #include <libfdt.h>
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
Ignore -Wimplicit-int-conversion for libfdt.h to avoid the llvm warnings in
newer versions.

Signed-off-by: Amirreza Zarrabi <quic_azarrabi@quicinc.com>
Signed-off-by: Carl van Schaik <quic_cvanscha@quicinc.com>